### PR TITLE
Require Package['wget'] before running install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class composer (
     user    => $composer_user,
     creates => $composer_full_path,
     timeout => $download_timeout,
+    require => Package['wget'],
   }
 
   file { "${composer_target_dir}/${composer_command_name}":


### PR DESCRIPTION
I'm seeing issues in my environment where puppet attempts Exec['composer-install'] before installing the wget package. This PR is intended to make the dependency between Exec['composer-install'] and Package['wget'] explicit.
